### PR TITLE
Avoiding global variables

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,6 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    
+    <div data-js="root"></div>
   </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,16 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './styles/css/index.css';
-import App from './App';
-import * as serviceWorker from './serviceWorker';
+import "./styles/css/index.css";
+
+import * as serviceWorker from "./serviceWorker";
+
+import App from "./App";
+import React from "react";
+import ReactDOM from "react-dom";
 
 ReactDOM.render(
-    <React.StrictMode>
-        <App />
-    </React.StrictMode>,
-    document.getElementById('root')
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  document.querySelector('[data-js="root"]')
 );
 
 serviceWorker.register();


### PR DESCRIPTION
The problem with the JavaScript ID attribute is that it generates a Global variable. Global variables are almost always a bad idea, but how do you escape them in javascript? It's simple: it doesn't work, what we can do is minimize the number of global variables.

> ##  Justifications:

- Performance: In theory, the interpreter will seek the value of the global variable in a much smaller scope.
- Organization: The code is much clearer because the module's dependencies are explicit.
- Avoid conflicts: Some libraries can use the same variable: